### PR TITLE
Fix Python 3.8 type annotation error

### DIFF
--- a/composer.py
+++ b/composer.py
@@ -1,5 +1,6 @@
 import os
 import random
+from typing import List
 
 try:
     from dotenv import load_dotenv
@@ -128,7 +129,7 @@ def infer_tag(headline: str) -> str:
     return "#News"
 
 
-def infer_tags(headline: str, limit: int = 2) -> list[str]:
+def infer_tags(headline: str, limit: int = 2) -> List[str]:
     """Return up to ``limit`` hashtags related to ``headline``."""
     text = (headline or "").lower()
     tags = [tag for keyword, tag in TOPICAL_KEYWORDS.items() if keyword in text]


### PR DESCRIPTION
## Summary
- ensure compatibility with Python versions <3.9
- import `List` from `typing` and use it for `infer_tags` return type

## Testing
- `python3 -m py_compile composer.py bot.py news_fetcher.py quote_tweet_bot.py scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_687b29f741e4833094f17ea4028a2647