### PR TITLE
Add automatic quote tweets to scheduled posts

### DIFF
--- a/quote_tweet_bot.py
+++ b/quote_tweet_bot.py
@@ -335,32 +335,14 @@ if __name__ == "__main__":
         action="store_true",
         help="Continuously monitor trending topics and quote tweet",
     )
-    parser.add_argument(
-        "--trending",
-        action="store_true",
-        help="Quote tweet a single trending topic and exit",
-    )
     args = parser.parse_args()
 
     if args.monitor:
         monitor_trending_topics()
-    elif args.trending:
+    else:
         try:
             url = quote_trending_tweet()
             print(f"Quote tweet posted: {url}")
-        except Exception as exc:
-            logger.error("Failed to post trending quote tweet: %s", exc)
-    else:
-        url = input("Please paste the URL of the Tweet to quote-tweet: ")
-        try:
-            tweet_id = extract_tweet_id(url)
-            original_text = fetch_tweet_text(tweet_id)
-            generated_quote = generate_quote(
-                original_text, brand_voice="Patriot Lens"
-            )
-            final_quote = append_hashtags(generated_quote, original_text)
-            tweet_url = post_quote_tweet(final_quote, tweet_id)
-            print(f"Quote tweet posted: {tweet_url}")
         except Exception as exc:
             logger.error("Failed to post quote tweet: %s", exc)
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,6 +1,6 @@
 from apscheduler.events import EVENT_SCHEDULER_STARTED
 from apscheduler.schedulers.blocking import BlockingScheduler
-from bot import authenticate_twitter, post_latest_tweets
+from bot import authenticate_twitter, post_scheduled_tweet
 import logging
 import pytz
 
@@ -23,11 +23,11 @@ def schedule_jobs():
     # Post at 08:00, 12:00,  18:00, 20:00, 22:00 Eastern time each day
     for hour in (8, 12, 18, 20, 22):
         sched.add_job(
-            post_latest_tweets,
+            post_scheduled_tweet,
             trigger="cron",
             hour=hour,
             minute=0,
-            args=[api, 1],
+            args=[api],
             jitter=RANDOM_JITTER_SECONDS,
             id=f"tweet_{hour}",
         )


### PR DESCRIPTION
## Summary
- track tweet count to rotate in a quote tweet every fourth post
- schedule job now chooses between headline tweets and trending quote tweets automatically
- quote_tweet_bot defaults to quoting a trending tweet without manual URLs

## Testing
- `python -m py_compile bot.py scheduler.py quote_tweet_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1100922e08330b5bfcbaf4c7a8a40